### PR TITLE
COMPASS-3634-3636 - Remove explain, indexes, validation from data lake

### DIFF
--- a/src/components/collection/collection.jsx
+++ b/src/components/collection/collection.jsx
@@ -12,7 +12,8 @@ class Collection extends Component {
   static displayName = 'CollectionComponent';
 
   static propTypes = {
-    namespace: PropTypes.string
+    namespace: PropTypes.string,
+    isDataLake: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -93,6 +94,10 @@ class Collection extends Component {
   }
 
   roleFiltered(role) {
+    if (['Indexes', 'Validation', 'ExplainPlan'].includes(role.name)
+        && this.props.isDataLake) {
+      return true;
+    }
     const serverVersion = global.hadronApp.instance.build.version;
     return (role.minimumServerVersion && !semver.gte(serverVersion, role.minimumServerVersion));
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,7 +6,8 @@ class Plugin extends Component {
   static displayName = 'CollectionPlugin';
 
   static propTypes = {
-    namespace: PropTypes.string
+    namespace: PropTypes.string,
+    isDataLake: PropTypes.bool
   };
 
   /**
@@ -15,7 +16,7 @@ class Plugin extends Component {
    * @returns {React.Component} The rendered component.
    */
   render() {
-    return (<Collection namespace={this.props.namespace} />);
+    return (<Collection namespace={this.props.namespace} isDataLake={this.props.isDataLake}/>);
   }
 }
 


### PR DESCRIPTION
Filter out tabs that should not be shown when connecting to data lake. The `isDataLake` prop is passed by the home plugin.


The home plugin passing the prop is part of this PR: mongodb-js/compass-home#2.

TODO: This is not yet rebased with master because I wasn't sure how to get the prop `isDataLake` from the home plugin (i.e. whatever gets added as the top-level component to the role) to the collection component where the tab filtering happens. Now Workspace is the top level component and I'm not sure where the Collection component is getting instantiated.