### PR TITLE
COMPASS-3705: Drag and Drop is broken in Aggregation Pipeline Builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,11 +264,53 @@
         "semver": "^5.6.0"
       },
       "dependencies": {
+        "dnd-core": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-7.7.0.tgz",
+          "integrity": "sha512-+YqwflWEY1MEAEl2QiEiRaglYkCwIZryyQwximQGuTOm/ns7fS6Lg/i7OCkrtjM10D5FhArf/VUHIL4ZaRBK0g==",
+          "dev": true,
+          "requires": {
+            "asap": "^2.0.6",
+            "invariant": "^2.2.4",
+            "redux": "^4.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
         "mongodb-redux-common": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/mongodb-redux-common/-/mongodb-redux-common-0.0.2.tgz",
           "integrity": "sha512-gM0YByWsqU0ID01GX0rOee9vH/RiLapF9M+Jg1S8ApBZHfN3353tLQfc7Azh8pg8gwSDvVLGOohqH94GXW3XDg==",
           "dev": true
+        },
+        "react-dnd": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.7.0.tgz",
+          "integrity": "sha512-anpJDKMgdXE6kXvtBFmIAe1fuaexpVy7meUyNjiTfCnjQ1mRvnttGTVvcW9fMKijsUQYadiyvzd3BRxteFuVXg==",
+          "dev": true,
+          "requires": {
+            "@types/hoist-non-react-statics": "^3.3.1",
+            "dnd-core": "^7.7.0",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.1.0",
+            "shallowequal": "^1.1.0"
+          }
+        },
+        "react-dnd-html5-backend": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-7.7.0.tgz",
+          "integrity": "sha512-JgKmWOxqorFyfGPeWV+SAPhVGFe6+LrOR24jETE9rrYZU5hCppzwK9ujjS508kWibeDvbfEgi9j5qC2wB1/MoQ==",
+          "dev": true,
+          "requires": {
+            "dnd-core": "^7.7.0"
+          }
         },
         "redux": {
           "version": "4.0.4",
@@ -1194,11 +1236,48 @@
         "react-treebeard": "^2.1.0"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "@types/node": {
       "version": "8.10.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
       "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
       "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.16.tgz",
+      "integrity": "sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
     },
     "@typescript-eslint/typescript-estree": {
       "version": "1.4.2",
@@ -2032,7 +2111,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asar": {
       "version": "0.13.1",
@@ -2363,13 +2443,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -4427,6 +4509,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -5203,11 +5286,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "chardet": {
       "version": "0.4.2",
@@ -7192,28 +7270,6 @@
         }
       }
     },
-    "dnd-core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-7.2.0.tgz",
-      "integrity": "sha512-KUCI+m2Q4k3QlWWsiyUu2R/d0nJo3oGHknM/lGOD4u1XPA4O+LJyYe7PQBzY4J6ehaHGoQ/soTUu/KfaLSOL8w==",
-      "requires": {
-        "asap": "^2.0.6",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.11",
-        "redux": "^4.0.1"
-      },
-      "dependencies": {
-        "redux": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
-          "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        }
-      }
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -7904,6 +7960,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -9333,6 +9390,7 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -9346,7 +9404,8 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         }
       }
     },
@@ -9773,7 +9832,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9797,13 +9857,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9820,19 +9882,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9963,7 +10028,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9977,6 +10043,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9993,6 +10060,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10001,13 +10069,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10028,6 +10098,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10116,7 +10187,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10130,6 +10202,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10225,7 +10298,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10267,6 +10341,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10288,6 +10363,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10336,13 +10412,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10598,13 +10676,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10929,6 +11009,26 @@
         "react-tooltip": "^3.2.6"
       },
       "dependencies": {
+        "dnd-core": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-7.7.0.tgz",
+          "integrity": "sha512-+YqwflWEY1MEAEl2QiEiRaglYkCwIZryyQwximQGuTOm/ns7fS6Lg/i7OCkrtjM10D5FhArf/VUHIL4ZaRBK0g==",
+          "dev": true,
+          "requires": {
+            "asap": "^2.0.6",
+            "invariant": "^2.2.4",
+            "redux": "^4.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
         "lodash.isarray": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
@@ -10940,6 +11040,38 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
           "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
           "dev": true
+        },
+        "react-dnd": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.7.0.tgz",
+          "integrity": "sha512-anpJDKMgdXE6kXvtBFmIAe1fuaexpVy7meUyNjiTfCnjQ1mRvnttGTVvcW9fMKijsUQYadiyvzd3BRxteFuVXg==",
+          "dev": true,
+          "requires": {
+            "@types/hoist-non-react-statics": "^3.3.1",
+            "dnd-core": "^7.7.0",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.1.0",
+            "shallowequal": "^1.1.0"
+          }
+        },
+        "react-dnd-html5-backend": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-7.7.0.tgz",
+          "integrity": "sha512-JgKmWOxqorFyfGPeWV+SAPhVGFe6+LrOR24jETE9rrYZU5hCppzwK9ujjS508kWibeDvbfEgi9j5qC2wB1/MoQ==",
+          "dev": true,
+          "requires": {
+            "dnd-core": "^7.7.0"
+          }
+        },
+        "redux": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+          "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
         }
       }
     },
@@ -11171,7 +11303,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -11480,6 +11613,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -12096,7 +12230,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -12205,6 +12340,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -16562,7 +16698,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -17170,7 +17306,7 @@
         "async": "^2.5.0",
         "bugsnag-js": "^3.2.0",
         "caller-id": "^0.1.0",
-        "debug": "github:mongodb-js/debug#f389ed0b1109752ceea04ea39c7ca55d04f9eaa6",
+        "debug": "github:mongodb-js/debug#v2.2.3",
         "lodash": "^4.13.1",
         "mongodb-ns": "^2.0.0",
         "mongodb-redact": "0.1.0",
@@ -17230,7 +17366,7 @@
         "lodash.defaults": "^4.2.0",
         "lodash.uniq": "^4.5.0",
         "minimist": "^1.2.0",
-        "pre-commit": "github:mongodb-js/pre-commit#f4158768a7ef58b46808cc09a6f6a0994c0baa67",
+        "pre-commit": "github:mongodb-js/pre-commit",
         "precinct": "^6.1.0"
       },
       "dependencies": {
@@ -17630,7 +17766,7 @@
       "dev": true,
       "requires": {
         "bson": "^1.0.9",
-        "context-eval": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
+        "context-eval": "github:durran/context-eval",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -18349,6 +18485,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -18730,6 +18867,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -19099,7 +19237,8 @@
           "version": "1.1.6",
           "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -19210,6 +19349,7 @@
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -19262,7 +19402,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -19565,7 +19706,8 @@
           "version": "1.6.1",
           "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -20470,7 +20612,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -22945,6 +23088,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -23438,38 +23582,6 @@
         }
       }
     },
-    "react-dnd": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.3.2.tgz",
-      "integrity": "sha512-chMQT4y+6CTQdRSpNEl+0JTNevCAkE7TmDewqF2GVejsgdCtVEMz/3SGk+fluMXMYPfhYlMDMHa+xWWO5QfM8Q==",
-      "requires": {
-        "dnd-core": "^7.2.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.1.0",
-        "lodash": "^4.17.11",
-        "recompose": "^0.30.0",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
-      }
-    },
-    "react-dnd-html5-backend": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-7.2.0.tgz",
-      "integrity": "sha512-1cyyiE1TRd7cTtPWvWWNxQdWxpv4ikyrvBn+fJwKqLjsRhhSdjlANZeJBYtBTO7Zf25YLzxVyO17nwFLMdjFAA==",
-      "requires": {
-        "dnd-core": "^7.2.0",
-        "lodash": "^4.17.11"
-      }
-    },
     "react-docgen": {
       "version": "3.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-rc.2.tgz",
@@ -23703,6 +23815,16 @@
         "react-input-autosize": "^2.1.2"
       }
     },
+    "react-sortable-hoc": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.10.1.tgz",
+      "integrity": "sha512-eVyv5rrK6qY9bG60bboRY78In7OpdRRg+hxp4QMLIjC/UJaFSU7exTYd0764GtXvBqh+b+faYGzren5/ffRYKw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.7"
+      }
+    },
     "react-split-pane": {
       "version": "0.1.85",
       "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.85.tgz",
@@ -23883,26 +24005,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "recursive-readdir": {
@@ -24559,7 +24661,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "safer-eval": {
       "version": "1.3.3",
@@ -24786,7 +24889,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -24813,7 +24917,8 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -27145,7 +27250,8 @@
     "ua-parser-js": {
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -28577,7 +28683,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -173,9 +173,8 @@
     "lodash.filter": "^4.6.0",
     "lodash.isempty": "^4.4.0",
     "mongodb-ns": "^2.0.0",
-    "react-dnd": "^7.3.2",
-    "react-dnd-html5-backend": "^7.2.0",
     "react-redux": "^5.0.6",
+    "react-sortable-hoc": "^1.10.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.3.0"
   }

--- a/src/components/collection-tab/collection-tab.jsx
+++ b/src/components/collection-tab/collection-tab.jsx
@@ -1,65 +1,14 @@
 import React, { PureComponent } from 'react';
-import { DragSource, DropTarget } from 'react-dnd';
-import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import styles from './collection-tab.less';
 
 /**
- * Behaviour for the tab drag source.
- */
-const tabSource = {
-  beginDrag(props) {
-    return {
-      index: props.index
-    };
-  }
-};
-
-/**
- * Behaviour for the tab drop target.
- */
-const tabTarget = {
-  hover(props, monitor, component) {
-    const fromIndex = monitor.getItem().index;
-    const toIndex = props.index;
-
-    if (fromIndex !== toIndex) {
-      // Determine rectangle on screen
-      const hoverBoundingRect = findDOMNode(component).getBoundingClientRect();
-      const hoverMiddleX = 100; // This is static.
-      // Determine mouse position
-      const clientOffset = monitor.getClientOffset();
-      // Get pixels to the left
-      const hoverClientX = clientOffset.x - hoverBoundingRect.left;
-      // Dragging to the left
-      if (fromIndex < toIndex && hoverClientX > hoverMiddleX) {
-        return;
-      }
-      // Dragging to the right
-      if (fromIndex > toIndex && hoverClientX < hoverMiddleX) {
-        return;
-      }
-      props.moveTab(fromIndex, toIndex);
-      // This prevents us from overloading the store with stageMoved actions.
-      monitor.getItem().index = toIndex;
-    }
-  }
-};
-
-/**
  * Display a single stage in the aggregation pipeline.
  *
  * Decorators added for giving the component drag/drop behaviour.
  */
-@DropTarget('Stage', tabTarget, connect => ({
-  connectDropTarget: connect.dropTarget()
-}))
-@DragSource('Stage', tabSource, (connect, monitor) => ({
-  connectDragSource: connect.dragSource(),
-  isDragging: monitor.didDrop() ? false : monitor.isDragging()
-}))
 class CollectionTab extends PureComponent {
   static displayName = 'CollectionTabComponent';
 
@@ -68,8 +17,6 @@ class CollectionTab extends PureComponent {
     isActive: PropTypes.bool.isRequired,
     isReadonly: PropTypes.bool.isRequired,
     closeTab: PropTypes.func.isRequired,
-    connectDragSource: PropTypes.func.isRequired,
-    connectDropTarget: PropTypes.func.isRequired,
     selectTab: PropTypes.func.isRequired,
     moveTab: PropTypes.func.isRequired,
     activeSubTabName: PropTypes.string.isRequired,
@@ -152,26 +99,22 @@ class CollectionTab extends PureComponent {
       [styles['collection-tab-is-active']]: this.props.isActive
     });
 
-    return this.props.connectDragSource(
-      this.props.connectDropTarget(
-        <div ref={this.tabRef} className={tabClass}>
-          <div className={classnames(styles['collection-tab-info'])} onClick={this.selectTab}>
-            <div className={classnames(styles['collection-tab-info-label'])}>
-              <div className={classnames(styles['collection-tab-info-ns'])}>
-                {this.props.namespace}
-              </div>
-              {this.renderReadonly()}
-            </div>
-            <div className={classnames(styles['collection-tab-info-subtab'])}>
-              {this.props.activeSubTabName}
-            </div>
+    return (<div ref={this.tabRef} className={tabClass}>
+      <div className={classnames(styles['collection-tab-info'])} onClick={this.selectTab}>
+        <div className={classnames(styles['collection-tab-info-label'])}>
+          <div className={classnames(styles['collection-tab-info-ns'])}>
+            {this.props.namespace}
           </div>
-          <div className={classnames(styles['collection-tab-close'])} onClick={this.closeTab}>
-            <i className="fa fa-times" aria-hidden />
-          </div>
+          {this.renderReadonly()}
         </div>
-      )
-    );
+        <div className={classnames(styles['collection-tab-info-subtab'])}>
+          {this.props.activeSubTabName}
+        </div>
+      </div>
+      <div className={classnames(styles['collection-tab-close'])} onClick={this.closeTab}>
+        <i className="fa fa-times" aria-hidden />
+      </div>
+    </div>);
   }
 }
 

--- a/src/components/collection-tab/collection-tab.less
+++ b/src/components/collection-tab/collection-tab.less
@@ -7,18 +7,20 @@
 }
 
 .collection-tab {
+  background-color: @gray8;
   border-bottom: 1px @gray6 solid;
   border-left: 1px @gray6 solid;
   border-right: 1px @gray6 solid;
   border-top: 1px @gray6 solid;
   border-radius: 4px 4px 0px 0px;
-  padding: 1px 5px 1px 8px;
+  padding: 2px 5px 2px 8px;
   display: flex;
   flex-grow: 1;
   min-width: 200px;
   max-width: 200px;
   color: @gray4;
   cursor: pointer;
+  height: 42px;
 
   &-info {
     padding: 0px 5px 0px 5px;

--- a/src/components/collection-tab/collection-tab.spec.js
+++ b/src/components/collection-tab/collection-tab.spec.js
@@ -6,7 +6,6 @@ import CollectionTab from 'components/collection-tab';
 import styles from './collection-tab.less';
 
 describe('CollectionTab [Component]', () => {
-  const connect = (c) => { return c; };
   const localAppRegistry = new AppRegistry();
 
   context('when the tab is active', () => {
@@ -20,14 +19,12 @@ describe('CollectionTab [Component]', () => {
       selectTabSpy = sinon.spy();
       moveTabSpy = sinon.spy();
       component = mount(
-        <CollectionTab.DecoratedComponent
+        <CollectionTab
           namespace="db.coll"
           activeSubTabName="Documents"
           isActive
           isReadonly={false}
           index={1}
-          connectDropTarget={connect}
-          connectDragSource={connect}
           localAppRegistry={localAppRegistry}
           closeTab={closeTabSpy}
           moveTab={moveTabSpy}
@@ -77,14 +74,12 @@ describe('CollectionTab [Component]', () => {
       selectTabSpy = sinon.spy();
       moveTabSpy = sinon.spy();
       component = mount(
-        <CollectionTab.DecoratedComponent
+        <CollectionTab
           namespace="db.coll"
           activeSubTabName="Documents"
           isActive={false}
           isReadonly={false}
           index={1}
-          connectDropTarget={connect}
-          connectDragSource={connect}
           localAppRegistry={localAppRegistry}
           closeTab={closeTabSpy}
           moveTab={moveTabSpy}
@@ -138,14 +133,12 @@ describe('CollectionTab [Component]', () => {
       selectTabSpy = sinon.spy();
       moveTabSpy = sinon.spy();
       component = mount(
-        <CollectionTab.DecoratedComponent
+        <CollectionTab
           namespace="db.coll"
           subTab="Documents"
           isActive
           index={1}
           isReadonly
-          connectDropTarget={connect}
-          connectDragSource={connect}
           localAppRegistry={localAppRegistry}
           closeTab={closeTabSpy}
           moveTab={moveTabSpy}

--- a/src/components/workspace/workspace.jsx
+++ b/src/components/workspace/workspace.jsx
@@ -181,6 +181,7 @@ class Workspace extends PureComponent {
       lockAxis="x"
       distance={10}
       onSortEnd={this.onSortEnd}
+      helperClass={classnames(styles['workspace-tabs-sortable-clone'])}
     />);
   }
 

--- a/src/components/workspace/workspace.jsx
+++ b/src/components/workspace/workspace.jsx
@@ -2,8 +2,9 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { DragDropContext } from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+
+import {SortableContainer, SortableElement} from 'react-sortable-hoc';
+
 import {
   createNewTab,
   selectOrCreateTab,
@@ -43,7 +44,6 @@ const KEY_OPEN_BRKT = 219;
 /**
  * The collection workspace contains tabs of multiple collections.
  */
-@DragDropContext(HTML5Backend)
 class Workspace extends PureComponent {
   static displayName = 'Workspace';
 
@@ -84,6 +84,10 @@ class Workspace extends PureComponent {
     window.removeEventListener('keydown', this.boundHandleKeypress);
   }
 
+  onSortEnd = ({oldIndex, newIndex}) => {
+    this.props.moveTab(oldIndex, newIndex);
+  }
+
   /**
    * Handle key press. This listens for CTRL/CMD+T and CTRL/CMD+W to control
    * natural opening and closing of collection tabs. CTRL/CMD+SHIFT+] and
@@ -99,15 +103,13 @@ class Workspace extends PureComponent {
         } else if (evt.keyCode === KEY_OPEN_BRKT) {
           this.props.prevTab();
         }
-      } else {
-        if (evt.keyCode === KEY_W) {
-          this.props.closeTab(this.props.tabs.findIndex(tab => tab.isActive));
-          if (this.props.tabs.length > 0) {
-            evt.preventDefault();
-          }
-        } else if (evt.keyCode === KEY_T) {
-          this.props.createNewTab(this.activeNamespace());
+      } else if (evt.keyCode === KEY_W) {
+        this.props.closeTab(this.props.tabs.findIndex(tab => tab.isActive));
+        if (this.props.tabs.length > 0) {
+          evt.preventDefault();
         }
+      } else if (evt.keyCode === KEY_T) {
+        this.props.createNewTab(this.activeNamespace());
       }
     }
   }
@@ -136,27 +138,50 @@ class Workspace extends PureComponent {
     return activeTab ? activeTab.sourceName : undefined;
   }
 
+  renderTab = (tab, i) => {
+    return (
+      <CollectionTab
+        key={i}
+        index={i}
+        namespace={tab.namespace}
+        localAppRegistry={tab.localAppRegistry}
+        isReadonly={tab.isReadonly}
+        isActive={tab.isActive}
+        closeTab={this.props.closeTab}
+        activeSubTabName={tab.activeSubTabName}
+        selectTab={this.props.selectTab}
+        moveTab={this.props.moveTab} />
+    );
+  }
+
   /**
    * Render the tabs.
    *
    * @returns {Component} The component.
    */
   renderTabs() {
-    return this.props.tabs.map((tab, i) => {
-      return (
-        <CollectionTab
-          key={i}
-          index={i}
-          namespace={tab.namespace}
-          localAppRegistry={tab.localAppRegistry}
-          isReadonly={tab.isReadonly}
-          isActive={tab.isActive}
-          closeTab={this.props.closeTab}
-          activeSubTabName={tab.activeSubTabName}
-          selectTab={this.props.selectTab}
-          moveTab={this.props.moveTab} />
-      );
+    const SortableItem = SortableElement(({value}) => this.renderTab(value.tab, value.index));
+
+
+    const SortableList = SortableContainer(({items}) => {
+      return (<div className={classnames(styles['workspace-tabs-sortable-list'])}>
+        {items.map(
+          (tab, index) => (<SortableItem
+            key={`tab-${index}`}
+            index={index}
+            value={{ tab: tab, index: index }}
+          />)
+        )}
+      </div>);
     });
+
+    return (<SortableList
+      items={this.props.tabs}
+      axis="x"
+      lockAxis="x"
+      distance={10}
+      onSortEnd={this.onSortEnd}
+    />);
   }
 
   /**

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -15,7 +15,7 @@
     z-index: 50;
     align-items: center;
 
-    &-container {
+    &-container, &-sortable-list {
       flex-grow: 1;
       display: flex;
       align-items: center;

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -7,24 +7,33 @@
   flex-direction: column;
 
   &-tabs {
-    height: 40px;
+    height: 44px;
     width: 100%;
     display: flex;
     border-bottom: 1px @gray6 solid;
     background-color: @gray8;
-    z-index: 50;
     align-items: center;
 
     &-sortable-clone {
+      pointer-events: auto !important;
+      cursor: grabbing !important;
+      cursor: -moz-grabbing !important;
+      cursor: -webkit-grabbing !important;
+
       z-index: 50;
     }
 
     &-container, &-sortable-list {
+      user-select: none;
       flex-grow: 1;
       display: flex;
       align-items: center;
-      overflow-x: hidden;
-      height: 40px;
+      overflow: hidden;
+
+      * {
+        user-select: none;
+        -webkit-user-select: none;
+      }
     }
 
     &-prev, &-next {

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -15,6 +15,10 @@
     z-index: 50;
     align-items: center;
 
+    &-sortable-clone {
+      z-index: 50;
+    }
+
     &-container, &-sortable-list {
       flex-grow: 1;
       display: flex;

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -7,13 +7,12 @@
   flex-direction: column;
 
   &-tabs {
-    height: 44px;
     width: 100%;
     display: flex;
     border-bottom: 1px @gray6 solid;
     background-color: @gray8;
     align-items: center;
-
+    min-height: 40px;
     &-sortable-clone {
       pointer-events: auto !important;
       cursor: grabbing !important;


### PR DESCRIPTION
This is a prerequisite to fix COMPASS-3705. We replace `react-dnd` with `react-sortable-hoc` so that there is no interference between the drag and drop components and we can use `react-dnd` in the Aggregation Pipeline Builder.

Has to be released for https://github.com/mongodb-js/compass-aggregations/pull/107 to work.