### PR TITLE
COMPASS-4353 - Do not display view information if not view

### DIFF
--- a/src/components/collection-header/collection-header.jsx
+++ b/src/components/collection-header/collection-header.jsx
@@ -69,6 +69,27 @@ class CollectionHeader extends Component {
   }
 
   /**
+   * Renders view information if the collection is a view.
+   *
+   * @returns {Component} The component.
+   */
+  renderViewInformation() {
+    if (this.props.sourceName) {
+      return (
+        <div>
+          <span
+            className={classnames(styles['collection-header-title-readonly-on'])}
+            title={this.props.sourceName}>
+            (view on: {this.props.sourceName})
+          </span>
+          {this.renderModifySource()}
+          {this.renderReturnToView()}
+        </div>
+      );
+    }
+  }
+
+  /**
    * Render the readonly icon if collection is readonly.
    *
    * @returns {Component} The component.
@@ -77,13 +98,7 @@ class CollectionHeader extends Component {
     if (this.props.isReadonly) {
       return (
         <div className={classnames(styles['collection-header-title-readonly'])}>
-          <span
-            className={classnames(styles['collection-header-title-readonly-on'])}
-            title={this.props.sourceName}>
-            (view on: {this.props.sourceName})
-          </span>
-          {this.renderModifySource()}
-          {this.renderReturnToView()}
+          {this.renderViewInformation()}
           <span className={classnames(styles['collection-header-title-readonly-indicator'])}>
             <i className="fa fa-eye" aria-hidden="true" />
             Read Only

--- a/src/components/collection-header/collection-header.spec.js
+++ b/src/components/collection-header/collection-header.spec.js
@@ -88,4 +88,38 @@ describe('CollectionHeader [Component]', () => {
       expect(component.find('.fa-eye')).to.be.present();
     });
   });
+
+  context('when the collection is readonly but not a view', () => {
+    let component;
+    const statsStore = {};
+    const selectOrCreateTabSpy = sinon.spy();
+    const sourceName = null;
+    const sourceReadonly = false;
+
+    beforeEach(() => {
+      component = mount(
+        <CollectionHeader
+          isReadonly
+          sourceName={sourceName}
+          statsPlugin={statsPlugin}
+          statsStore={statsStore}
+          namespace="db.coll"
+          selectOrCreateTab={selectOrCreateTabSpy}
+          sourceReadonly={sourceReadonly} />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('does not the source collection', () => {
+      expect(component.find(`.${styles['collection-header-title-readonly-on']}`)).
+        to.be.empty;
+    });
+
+    it('renders the readonly icon', () => {
+      expect(component.find('.fa-eye')).to.be.present();
+    });
+  });
 });


### PR DESCRIPTION
Part of COMPASS-4353: If the collection is readonly but not a view, do not render view-specific information. (This should go together with https://github.com/mongodb-js/compass-sidebar/pull/128)

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
