### PR TITLE
Add nav to database in collection header, left align the new tab button

### DIFF
--- a/src/components/collection-header/collection-header.jsx
+++ b/src/components/collection-header/collection-header.jsx
@@ -6,13 +6,11 @@ import { TextButton } from 'hadron-react-buttons';
 
 import styles from './collection-header.less';
 
-/**
- * The collection header.
- */
 class CollectionHeader extends Component {
   static displayName = 'CollectionHeaderComponent';
 
   static propTypes = {
+    globalAppRegistry: PropTypes.func.isRequired,
     namespace: PropTypes.string.isRequired,
     isReadonly: PropTypes.bool.isRequired,
     statsPlugin: PropTypes.func.isRequired,
@@ -47,6 +45,10 @@ class CollectionHeader extends Component {
       this.props.sourceName,
       this.props.pipeline
     );
+  }
+
+  handleDBClick = (db) => {
+    this.props.globalAppRegistry.emit('select-database', db);
   }
 
   /**
@@ -160,12 +162,15 @@ class CollectionHeader extends Component {
     });
 
     return (
-      <div className={classnames(styles['collection-header'])}>
+      <div className={styles['collection-header']}>
         {this.renderStats()}
         <div className={titleClass} title={`${database}.${collection}`}>
-          <span className={classnames(styles['collection-header-title-db'])}>
+          <a
+            className={styles['collection-header-title-db']}
+            onClick={() => this.handleDBClick(database)}
+          >
             {database}
-          </span>
+          </a>
           <span>.</span>
           <span className={collectionClass}>
             {collection}

--- a/src/components/collection-header/collection-header.less
+++ b/src/components/collection-header/collection-header.less
@@ -30,6 +30,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      cursor: pointer;
     }
 
     &-collection {

--- a/src/components/collection-header/collection-header.spec.js
+++ b/src/components/collection-header/collection-header.spec.js
@@ -17,6 +17,7 @@ describe('CollectionHeader [Component]', () => {
       component = mount(
         <CollectionHeader
           isReadonly={false}
+          globalAppRegistry={{}}
           statsPlugin={statsPlugin}
           statsStore={statsStore}
           namespace="db.coll"
@@ -52,6 +53,7 @@ describe('CollectionHeader [Component]', () => {
       component = mount(
         <CollectionHeader
           isReadonly
+          globalAppRegistry={{}}
           sourceName="orig.coll"
           statsPlugin={statsPlugin}
           statsStore={statsStore}
@@ -120,6 +122,39 @@ describe('CollectionHeader [Component]', () => {
 
     it('renders the readonly icon', () => {
       expect(component.find('.fa-eye')).to.be.present();
+    });
+  });
+
+  context('when the db name is clicked', () => {
+    it('emits the open event to the app registry', () => {
+      const statsStore = {};
+      const selectOrCreateTabSpy = sinon.spy();
+      const sourceReadonly = false;
+
+      let emmittedEventName;
+      let emmittedDbName;
+
+      const component = mount(
+        <CollectionHeader
+          isReadonly={false}
+          globalAppRegistry={{
+            emit: (eventName, dbName) => {
+              emmittedEventName = eventName;
+              emmittedDbName = dbName;
+            }
+          }}
+          sourceName="orig.coll"
+          statsPlugin={statsPlugin}
+          statsStore={statsStore}
+          namespace="db.coll"
+          selectOrCreateTab={selectOrCreateTabSpy}
+          sourceReadonly={sourceReadonly} />
+      );
+
+      expect(component.find(`.${styles['collection-header-title-db']}`)).to.be.present();
+      component.find(`.${styles['collection-header-title-db']}`).simulate('click');
+      expect(emmittedEventName).to.equal('select-database');
+      expect(emmittedDbName).to.equal('db');
     });
   });
 });

--- a/src/components/collection/collection.jsx
+++ b/src/components/collection/collection.jsx
@@ -66,6 +66,7 @@ class Collection extends Component {
       <div className={classnames(styles.collection, 'clearfix')}>
         <div className={classnames(styles['collection-container'])}>
           <CollectionHeader
+            globalAppRegistry={this.props.globalAppRegistry}
             namespace={this.props.namespace}
             isReadonly={this.props.isReadonly}
             statsPlugin={this.props.statsPlugin}

--- a/src/components/create-tab/create-tab.jsx
+++ b/src/components/create-tab/create-tab.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import styles from './create-tab.less';
 
@@ -32,7 +31,7 @@ class CreateTab extends PureComponent {
    */
   render() {
     return (
-      <div className={classnames(styles['create-tab'])} onClick={this.createTab}>
+      <div className={styles['create-tab']} onClick={this.createTab}>
         +
       </div>
     );

--- a/src/components/workspace/workspace.jsx
+++ b/src/components/workspace/workspace.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 
@@ -162,9 +161,8 @@ class Workspace extends PureComponent {
   renderTabs() {
     const SortableItem = SortableElement(({value}) => this.renderTab(value.tab, value.index));
 
-
     const SortableList = SortableContainer(({items}) => {
-      return (<div className={classnames(styles['workspace-tabs-sortable-list'])}>
+      return (<div className={styles['workspace-tabs-sortable-list']}>
         {items.map(
           (tab, index) => (<SortableItem
             key={`tab-${index}`}
@@ -181,7 +179,7 @@ class Workspace extends PureComponent {
       lockAxis="x"
       distance={10}
       onSortEnd={this.onSortEnd}
-      helperClass={classnames(styles['workspace-tabs-sortable-clone'])}
+      helperClass={styles['workspace-tabs-sortable-clone']}
     />);
   }
 
@@ -228,12 +226,12 @@ class Workspace extends PureComponent {
    */
   render() {
     return (
-      <div className={classnames(styles.workspace)}>
-        <div className={classnames(styles['workspace-tabs'])}>
-          <div onClick={this.props.prevTab} className={classnames(styles['workspace-tabs-prev'])}>
+      <div className={styles.workspace}>
+        <div className={styles['workspace-tabs']}>
+          <div onClick={this.props.prevTab} className={styles['workspace-tabs-prev']}>
             <i className="fa fa-chevron-left" aria-hidden/>
           </div>
-          <div className={classnames(styles['workspace-tabs-container'])}>
+          <div className={styles['workspace-tabs-container']}>
             {this.renderTabs()}
             <CreateTab
               createNewTab={this.props.createNewTab}
@@ -241,11 +239,13 @@ class Workspace extends PureComponent {
               activeIsReadonly={this.activeIsReadonly()}
               activeSourceName={this.activeSourceName()} />
           </div>
-          <div onClick={this.props.nextTab} className={classnames(styles['workspace-tabs-next'])}>
-            <i className="fa fa-chevron-right" aria-hidden/>
+          <div className={styles['workspace-tabs-right']}>
+            <div onClick={this.props.nextTab} className={styles['workspace-tabs-next']}>
+              <i className="fa fa-chevron-right" aria-hidden/>
+            </div>
           </div>
         </div>
-        <div className={classnames(styles['workspace-views'])}>
+        <div className={styles['workspace-views']}>
           {this.renderViews()}
         </div>
       </div>

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -24,7 +24,6 @@
 
     &-container, &-sortable-list {
       user-select: none;
-      flex-grow: 1;
       display: flex;
       align-items: center;
       overflow: hidden;
@@ -46,6 +45,10 @@
       border-radius: 4px;
       cursor: pointer;
       flex-shrink: 0;
+    }
+
+    &-right {
+      margin-left: auto;
     }
 
     &-prev {


### PR DESCRIPTION
PR has 2 small ux improvements:

Added nav to go to database from collection header (previously was not click-able):
![db-nav](https://user-images.githubusercontent.com/1791149/94166673-e68b0080-fe8b-11ea-8dd5-2974646e75d9.gif)

Moved the `+` new tab icon to be hugging the farthest right tab (was aligned on right):
![new-tab-placement](https://user-images.githubusercontent.com/1791149/94166659-e12db600-fe8b-11ea-8ea2-0d775d493c10.gif)