### PR TITLE
COMPASS-4434 - Preserve components for individual tabs

### DIFF
--- a/src/components/workspace/workspace.jsx
+++ b/src/components/workspace/workspace.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 
@@ -189,34 +190,35 @@ class Workspace extends PureComponent {
    * @returns {Component} The views.
    */
   renderViews() {
-    const activeTab = this.props.tabs.find((tab) => {
-      return tab.isActive;
-    });
-    if (activeTab) {
-      return (
+    return this.props.tabs.map((tab) => {
+      const viewTabClass = classnames({
+        [styles['workspace-view-tab']]: true,
+        hidden: !tab.isActive
+      });
+      return <div className={viewTabClass}>
         <Collection
-          key={activeTab.id}
-          id={activeTab.id}
-          namespace={activeTab.namespace}
-          isReadonly={activeTab.isReadonly}
-          sourceName={activeTab.sourceName}
-          editViewName={activeTab.editViewName}
-          sourceReadonly={activeTab.sourceReadonly}
-          sourceViewOn={activeTab.sourceViewOn}
-          tabs={activeTab.tabs}
-          views={activeTab.views}
-          scopedModals={activeTab.scopedModals}
-          queryHistoryIndexes={activeTab.queryHistoryIndexes}
-          statsPlugin={activeTab.statsPlugin}
-          statsStore={activeTab.statsStore}
-          activeSubTab={activeTab.activeSubTab}
-          pipeline={activeTab.pipeline}
+          key={tab.id}
+          id={tab.id}
+          namespace={tab.namespace}
+          isReadonly={tab.isReadonly}
+          sourceName={tab.sourceName}
+          editViewName={tab.editViewName}
+          sourceReadonly={tab.sourceReadonly}
+          sourceViewOn={tab.sourceViewOn}
+          tabs={tab.tabs}
+          views={tab.views}
+          scopedModals={tab.scopedModals}
+          queryHistoryIndexes={tab.queryHistoryIndexes}
+          statsPlugin={tab.statsPlugin}
+          statsStore={tab.statsStore}
+          activeSubTab={tab.activeSubTab}
+          pipeline={tab.pipeline}
           changeActiveSubTab={this.props.changeActiveSubTab}
           selectOrCreateTab={this.props.selectOrCreateTab}
           globalAppRegistry={this.props.appRegistry}
-          localAppRegistry={activeTab.localAppRegistry} />
-      );
-    }
+          localAppRegistry={tab.localAppRegistry} />
+        </div>;
+    });
   }
 
   /**

--- a/src/components/workspace/workspace.jsx
+++ b/src/components/workspace/workspace.jsx
@@ -195,7 +195,7 @@ class Workspace extends PureComponent {
         [styles['workspace-view-tab']]: true,
         hidden: !tab.isActive
       });
-      return <div className={viewTabClass}>
+      return (<div className={viewTabClass}>
         <Collection
           key={tab.id}
           id={tab.id}
@@ -217,7 +217,7 @@ class Workspace extends PureComponent {
           selectOrCreateTab={this.props.selectOrCreateTab}
           globalAppRegistry={this.props.appRegistry}
           localAppRegistry={tab.localAppRegistry} />
-        </div>;
+      </div>);
     });
   }
 

--- a/src/components/workspace/workspace.less
+++ b/src/components/workspace/workspace.less
@@ -67,4 +67,9 @@
     align-items: center;
     justify-content: center;
   }
+
+  &-view-tab {
+    height: 100%;
+    width: 100%;
+  }
 }

--- a/src/components/workspace/workspace.spec.js
+++ b/src/components/workspace/workspace.spec.js
@@ -8,7 +8,10 @@ describe.skip('Workspace [Component]', () => {
   let component;
   let prevTabSpy;
   let nextTabSpy;
-  const tabs = [];
+  const tabs = [
+    { isActive: true },
+    { isActive: false },
+  ];
 
   beforeEach(() => {
     prevTabSpy = sinon.spy();
@@ -39,6 +42,11 @@ describe.skip('Workspace [Component]', () => {
 
   it('renders the individual tabs', () => {
     expect(component.find(`.${styles['workspace-tabs-container']}`)).to.be.present();
+  });
+
+  it('renders one tab hidden, one not', () => {
+    expect(component.find(`.${styles['workspace-view-tab']}:not(.hidden)`)).to.be.present();
+    expect(component.find(`.${styles['workspace-view-tab']}.hidden`)).to.be.present();
   });
 
   context('when clicking the prev button', () => {


### PR DESCRIPTION
Do not unmound and remount components when switching tabs
to preserve their current state.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
